### PR TITLE
Initial clockboard binding implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pythonize"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445529621b8801c031b9e43f12f543fdf64379584646f132d6dcf2731c814e03"
+dependencies = [
+ "pyo3",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,8 +645,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "zonebuilder"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff733b272ea18d2612f2fb330cf00342c761d847ab53d542c391f948bec9cbd"
+source = "git+https://github.com/zonebuilders/zonebuilder-rust/#b3588689eb11f966ee6dc56e2f4c5416b819c533"
 dependencies = [
  "geo",
  "geographiclib-rs",
@@ -649,6 +658,9 @@ dependencies = [
 name = "zonebuilder-py"
 version = "0.1.0"
 dependencies = [
+ "geo",
+ "geojson",
  "pyo3",
+ "pythonize",
  "zonebuilder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,16 +408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pythonize"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445529621b8801c031b9e43f12f543fdf64379584646f132d6dcf2731c814e03"
-dependencies = [
- "pyo3",
- "serde",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +651,5 @@ dependencies = [
  "geo",
  "geojson",
  "pyo3",
- "pythonize",
  "zonebuilder",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zonebuilder = "0.1.0"
-
+# zonebuilder = "0.1.0"
+zonebuilder = { git = "https://github.com/zonebuilders/zonebuilder-rust/" }
+geojson = "0.22.2"
+geo = "0.17.1"
+pythonize = "0.15.0"
 
 [lib]
 name = "zonebuilder_py"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 zonebuilder = { git = "https://github.com/zonebuilders/zonebuilder-rust/" }
 geojson = "0.22.2"
 geo = "0.17.1"
-pythonize = "0.15.0"
 
 [lib]
 name = "zonebuilder_py"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,11 @@ impl Pyparams {
 
 #[pyfunction(kwargs = "**")]
 fn kwargsparse(kwargs: Option<&PyDict>) -> PyResult<Pyparams> {
+    let defaults = Pyparams::default();
     if kwargs.is_none() {
-        return Ok(Pyparams::default())
+        return Ok(defaults);
     }
     let udict = kwargs.unwrap();
-    let defaults = Params::default();
     let params = Pyparams {
         num_segments: match udict.get_item("num_segments") {
             Some(value) => value.extract()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,93 @@
-use zonebuilder;
-use pyo3::prelude::*;
+#[allow(unused)]
+use geo::{map_coords::MapCoordsInplace, Point};
+use pyo3::{prelude::*, types::PyDict, Python};
+use pythonize::pythonize;
+use zonebuilder::{self, Params};
 
 #[pyfunction]
 fn triangular_sequence(n: usize) -> Vec<f64> {
     zonebuilder::triangular_sequence(n)
 }
 
+#[pyclass]
+#[derive(Clone)]
+struct Pyparams {
+    num_segments: usize,
+    distances: Vec<f64>,
+    num_vertices_arc: usize,
+    precision: usize,
+    projected: bool,
+}
+impl Default for Pyparams {
+    fn default() -> Self {
+        Pyparams {
+            num_segments: 12,
+            distances: triangular_sequence(5),
+            num_vertices_arc: 10,
+            precision: 6,
+            projected: false,
+        }
+    }
+}
+impl Pyparams {
+    fn to_zb_params(&self) -> Params {
+        Params {
+            num_segments: self.num_segments,
+            distances: self.distances.clone(),
+            num_vertices_arc: self.num_vertices_arc,
+            precision: self.precision,
+            projected: self.projected,
+        }
+    }
+}
+
+#[pyfunction(kwargs = "**")]
+fn kwargsparse(kwargs: Option<&PyDict>) -> PyResult<Pyparams> {
+    if kwargs.is_none() {
+        return Ok(Pyparams::default())
+    }
+    let udict = kwargs.unwrap();
+    let defaults = Params::default();
+    let params = Pyparams {
+        num_segments: match udict.get_item("num_segments") {
+            Some(value) => value.extract()?,
+            None => defaults.num_segments,
+        },
+        distances: match udict.get_item("distances") {
+            Some(value) => value.extract()?,
+            None => defaults.distances,
+        },
+        num_vertices_arc: match udict.get_item("num_vertices_arc") {
+            Some(value) => value.extract()?,
+            None => defaults.num_vertices_arc,
+        },
+        precision: match udict.get_item("precision") {
+            Some(value) => value.extract()?,
+            None => defaults.precision,
+        },
+        projected: match udict.get_item("projected") {
+            Some(value) => value.extract()?,
+            None => defaults.projected,
+        },
+    };
+    Ok(params)
+}
+
+#[pyfunction]
+fn clockboard(center: [f64; 2], kwargs: Option<&PyDict>) -> PyResult<PyObject> {
+    let center_point = Point::new(center[0], center[1]);
+    let params = kwargsparse(kwargs)?;
+    let clockboard = zonebuilder::clockboard(center_point, params.to_zb_params());
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pythonize(py, &clockboard)?)
+}
+
 #[pymodule]
 fn zonebuilder_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(triangular_sequence, m)?)?;
+    m.add_function(wrap_pyfunction!(kwargsparse, m)?)?;
+    // m.add_class::<Params>()?;
+    m.add_function(wrap_pyfunction!(clockboard, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#[allow(unused)]
-use geo::{map_coords::MapCoordsInplace, Point};
+use geo::Point;
 use pyo3::{prelude::*, types::PyDict, Python};
 use zonebuilder::Params;
 
@@ -17,6 +16,7 @@ struct Pyparams {
     precision: usize,
     projected: bool,
 }
+
 impl Default for Pyparams {
     fn default() -> Self {
         let defaults = Params::default();
@@ -29,6 +29,7 @@ impl Default for Pyparams {
         }
     }
 }
+
 impl Pyparams {
     fn to_zb_params(&self) -> Params {
         Params {


### PR DESCRIPTION
Addresses #3 
Here is a binding for the clockboard function. To test it out, activate the local python environment, install `requirements.txt` on it, and do
```
maturin develop
python
>>from zonebuilder_py import *
>>clockboard(-1.5, 53.8)
```
This is the input from the clockboard example on `zonebuilder-rs`. The output will be a big geojson dump. Ideas for improving the implementation and adding testing are welcome.
